### PR TITLE
Open apple maps/google maps for school directions

### DIFF
--- a/.expo/prebuild/cached-packages.json
+++ b/.expo/prebuild/cached-packages.json
@@ -1,4 +1,4 @@
 {
-  "dependencies": "a06bda7503fb295938d1655ba00e9028140dcdc0",
+  "dependencies": "86b5d5c092fc62f645cd5d9dff45cf2b6a379704",
   "devDependencies": "381c21c424c14f73cfb2f94504ee6850fabd6f32"
 }

--- a/app.json
+++ b/app.json
@@ -33,7 +33,11 @@
     "web": {
       "favicon": "./assets/favicon.png"
     },
-    "plugins": ["expo-router", "@react-native-google-signin/google-signin"],
+    "plugins": [
+      "expo-router",
+      "@react-native-google-signin/google-signin",
+      "react-native-map-link"
+    ],
     "extra": {
       "router": {
         "origin": false

--- a/app/components/SchoolTransportDetails.tsx
+++ b/app/components/SchoolTransportDetails.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Dimensions, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { TouchableOpacity } from 'react-native-gesture-handler';
+import { showLocation } from 'react-native-map-link';
+import FaIcon from 'react-native-vector-icons/FontAwesome';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 
 import { listenToSchoolDirections, updateSchoolDirections } from '../firebase/util';
@@ -11,13 +14,34 @@ const screenHeight = Dimensions.get('window').height;
 interface ArticleHeaderProps {
   schoolName: string;
   location: string;
+  latitude: number;
+  longitude: number;
 }
 
 // Component to display the header with school name and location
-const ArticleHeader: React.FC<ArticleHeaderProps> = ({ schoolName, location }) => (
+const ArticleHeader: React.FC<ArticleHeaderProps> = ({
+  schoolName,
+  location,
+  latitude,
+  longitude,
+}) => (
   <View style={styles.headerContainer}>
     <Text style={styles.headerTitle}>{schoolName}</Text>
-    <Text style={styles.headerLocation}>{location}</Text>
+    <TouchableOpacity
+      onPress={() =>
+        showLocation({
+          latitude,
+          longitude,
+          googleForceLatLon: true, // force GoogleMaps to use the latitude and longitude for the query instead of the title
+          alwaysIncludeGoogle: true, // include Google Maps
+          title: schoolName, // display school name as the title in the map location
+        })
+      }>
+      <View style={styles.row}>
+        <FaIcon name="map-marker" size={20} color="#36afbc" />
+        <Text style={[styles.headerLocation]}>{location}</Text>
+      </View>
+    </TouchableOpacity>
   </View>
 );
 
@@ -97,6 +121,8 @@ export const SchoolTransportDetails: React.FC<SchoolTransportDetailsProps> = ({ 
             <ArticleHeader
               schoolName={directionsInfo.schoolName}
               location={directionsInfo.address}
+              latitude={directionsInfo.geoLat}
+              longitude={directionsInfo.geoLong}
             />
             <View style={styles.section}>
               <Text style={styles.header}>Directions</Text>
@@ -188,7 +214,14 @@ const styles = StyleSheet.create({
     marginBottom: 15,
   },
   headerLocation: {
-    fontSize: 12,
+    fontSize: 14,
+    fontWeight: 'bold',
+    paddingLeft: 10,
+    color: '#36afbc',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
   },
   button: {
     position: 'absolute',

--- a/app/components/SchoolTransportDetails.tsx
+++ b/app/components/SchoolTransportDetails.tsx
@@ -5,7 +5,11 @@ import { showLocation } from 'react-native-map-link';
 import FaIcon from 'react-native-vector-icons/FontAwesome';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 
-import { listenToSchoolDirections, updateSchoolDirections } from '../firebase/util';
+import {
+  SchoolDirections,
+  listenToSchoolDirections,
+  updateSchoolDirections,
+} from '../firebase/util';
 import EditText from './EditText';
 
 const screenHeight = Dimensions.get('window').height;
@@ -14,8 +18,8 @@ const screenHeight = Dimensions.get('window').height;
 interface ArticleHeaderProps {
   schoolName: string;
   location: string;
-  latitude: number;
-  longitude: number;
+  latitude: string;
+  longitude: string;
 }
 
 // Component to display the header with school name and location
@@ -218,6 +222,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     paddingLeft: 10,
     color: '#36afbc',
+    textDecorationLine: 'underline',
   },
   row: {
     flexDirection: 'row',

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "react-native-gesture-handler": "^2.16.2",
         "react-native-gifted-chat": "^2.4.0",
         "react-native-linear-gradient": "^2.8.3",
+        "react-native-map-link": "^3.4.1",
         "react-native-reanimated": "~3.10.1",
         "react-native-reanimated-carousel": "^3.5.1",
         "react-native-safe-area-context": "4.10.1",
@@ -15618,6 +15619,16 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-map-link": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/react-native-map-link/-/react-native-map-link-3.4.1.tgz",
+      "integrity": "sha512-Xgn4UcWFkEtQ5RDzJ2x97e1xQQpV4WK07n8oiNOJY1IE1hin9sls/DPa0ghVT+tSz/90bv4Dvum93lK6QaEVzQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-native": ">=0.40.0"
       }
     },
     "node_modules/react-native-parsed-text": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-native-gesture-handler": "^2.16.2",
     "react-native-gifted-chat": "^2.4.0",
     "react-native-linear-gradient": "^2.8.3",
+    "react-native-map-link": "^3.4.1",
     "react-native-reanimated": "~3.10.1",
     "react-native-reanimated-carousel": "^3.5.1",
     "react-native-safe-area-context": "4.10.1",


### PR DESCRIPTION
### Description

Adds apple maps/google maps redirect for school directions when user clicks on address

![image](https://github.com/DISC-NU/books-and-breakfast-app/assets/36573115/3e0cc043-494e-467a-a42d-0df7f94c8a9c)

### QA

Pick a school -> Directions -> click on the blue address, should see both Apple Maps and Google Maps options (on iOS). Clicking on either would take you to the school address in the respective map app

### Packages

react-native-map-link

### Checklist

- [x] Code compiles correctly
- [x] Added comments
- [x] Ran linter and made sure there were no errors
- [x] Extended the README / documentation, if necessary
